### PR TITLE
fix: correct socket path expansion and clone3 cgroup handling

### DIFF
--- a/nix/shell.nix
+++ b/nix/shell.nix
@@ -1,4 +1,4 @@
-{ pkgs, lib, ... }:
+{ pkgs, config, ... }:
 
 {
   packages = with pkgs; [
@@ -14,6 +14,6 @@
     LIBSECCOMP_LINK_TYPE = "dylib";
     LIBSECCOMP_LIB_PATH = "${pkgs.libseccomp}/lib";
     PKG_CONFIG_PATH = "${pkgs.libseccomp}/lib/pkgconfig";
-    LEEWARD_SOCKET = lib.mkDefault "\${DEVENV_STATE}/leeward.sock";
+    LEEWARD_SOCKET = "${config.env.DEVENV_STATE}/leeward.sock";
   };
 }


### PR DESCRIPTION
- Fix LEEWARD_SOCKET to expand DEVENV_STATE variable properly
- Make CLONE_INTO_CGROUP conditional on valid cgroup_fd
- Workers now spawn successfully without cgroup setup